### PR TITLE
Remove deprecated Tor Onion Service domain of X(Twitter)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ The Twitter servers secretly conceal the hyperlinks' destinations with shortened
 
 Please note that TLD will expand URLs from t.co to other shortened URLs, like bit.ly or mzl.la, if the user originally posted those shortened URLs, but it will not further expand the original shortened URLs to their final destinations.
 
-NOTE: This extension goes into action only while browsing twitter.com or twitter3e4tixl4xyajtrzo62zg5vztmjuricljdp2c5kshju4avyoid.onion and stays dormant when other websites are browsed.
+NOTE: This extension goes into action only while browsing twitter.com and stays dormant when other websites are browsed.
 
-The add-on can be enabled and disabled by clicking its icon from the browser toolbar. Once the add-on is installed and while it is enabled, it will wait in the background for a page from twitter.com or twitter3e4tixl4xyajtrzo62zg5vztmjuricljdp2c5kshju4avyoid.onion to be opened and only then it will go into action and scan the web page for any hyperlinks with shortened URLs and clean them.
+The add-on can be enabled and disabled by clicking its icon from the browser toolbar. Once the add-on is installed and while it is enabled, it will wait in the background for a page from twitter.com to be opened and only then it will go into action and scan the web page for any hyperlinks with shortened URLs and clean them.
 
 Twitter Link Deobfuscator only needs the minimum amount of permissions. It does not collect, use, store nor share user data.
 
@@ -28,7 +28,7 @@ You can then (or before) clone/download this Git repository and temporarily inst
 There is another way to install add-ons temporarily, and that is by using the [web-ext](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Getting_started_with_web-ext "Getting started with web-ext") command line tool. Web-ext is a Node.js module that can do a lot more than just allow installing add-ons but I leave that for you to discover.
 
 ## Disclaimer
-TLD is guaranteed to work correctly on [twitter.com](https://twitter.com "https://twitter.com"), the subdomain [mobile.twitter.com](https://mobile.twitter.com "https://mobile.twitter.com") which is the version optimized for mobile devices and the Tor onion domain [https://twitter3e4tixl4xyajtrzo62zg5vztmjuricljdp2c5kshju4avyoid.onion](https://twitter3e4tixl4xyajtrzo62zg5vztmjuricljdp2c5kshju4avyoid.onion "https://twitter3e4tixl4xyajtrzo62zg5vztmjuricljdp2c5kshju4avyoid.onion").
+TLD is guaranteed to work correctly on [twitter.com](https://twitter.com "https://twitter.com"), the subdomain [mobile.twitter.com](https://mobile.twitter.com "https://mobile.twitter.com") which is the version optimized for mobile devices.
 
 I cannot guarantee that it will work on any of its other subdomains (about.twitter.com, analytics.twitter.com, careers.twitter.com, data.twitter.com, developer.twitter.com, help.twitter.com, media.twitter.com, marketing.twitter.com etc.). Because not many people browse those subdomains and because there is not much user generated content there, in the sense of tweets, just some occasional quoted ones, I did not spend much time to make it work there. I intend to get to it at some point, but I don't know when. If someone says they need TLD to work on subdomains, I will make this a priority.
 

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -4,7 +4,7 @@
     "description": "The name of the extension."
   },
   "extensionDescription": {
-    "message": "Offenbart die tatsächlichen Ziele der Links und Twitter Cards in Tweets, Antworten als auch in Direktnachrichten, aber auch den \"Website\"-Link and andere, die gewöhnlich durch verkürzte URLs verschleiert werden. Die Erweiterung tritt nur in Aktion, wenn twitter.com oder twitter3e4tixl4xyajtrzo62zg5vztmjuricljdp2c5kshju4avyoid.onion besucht wird.",
+    "message": "Offenbart die tatsächlichen Ziele der Links und Twitter Cards in Tweets, Antworten als auch in Direktnachrichten, aber auch den \"Website\"-Link and andere, die gewöhnlich durch verkürzte URLs verschleiert werden. Die Erweiterung tritt nur in Aktion, wenn twitter.com besucht wird.",
     "description": "The description of the extension."
   },
   "enabledStateTitle": {

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -4,7 +4,7 @@
     "description": "The name of the extension."
   },
   "extensionDescription": {
-    "message": "Reveals the original destinations of the links and of the Twitter Cards from tweets and replies as well as from Direct Messages, but also the \"Website\" link and others, which are usually concealed using shortened URLs. The extension goes into action only while browsing twitter.com or twitter3e4tixl4xyajtrzo62zg5vztmjuricljdp2c5kshju4avyoid.onion.",
+    "message": "Reveals the original destinations of the links and of the Twitter Cards from tweets and replies as well as from Direct Messages, but also the \"Website\" link and others, which are usually concealed using shortened URLs. The extension goes into action only while browsing twitter.com.",
     "description": "The description of the extension."
   },
   "enabledStateTitle": {

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -4,7 +4,7 @@
     "description": "Le nom de l'extension."
   },
   "extensionDescription": {
-    "message": "Révèle les destinations originales des liens et des Cartes Twitter de tweets et de réponses ainsi que de Messages Directs, mais aussi le lien «Site Web» et d'autres, qui sont généralement cachés à l'aide des URL raccourcies. L'extension entre en action uniquement en naviguant sur twitter.com ou twitter3e4tixl4xyajtrzo62zg5vztmjuricljdp2c5kshju4avyoid.onion.",
+    "message": "Révèle les destinations originales des liens et des Cartes Twitter de tweets et de réponses ainsi que de Messages Directs, mais aussi le lien «Site Web» et d'autres, qui sont généralement cachés à l'aide des URL raccourcies. L'extension entre en action uniquement en naviguant sur twitter.com.",
     "description": "La description de l'extension."
   },
   "enabledStateTitle": {

--- a/_locales/ro/messages.json
+++ b/_locales/ro/messages.json
@@ -4,7 +4,7 @@
     "description": "Numele extensiei."
   },
   "extensionDescription": {
-    "message": "Dezvăluiește destinațiile originale ale link-urilor și ale Cardurilor Twitter din tweet-uri și răspunsuri cât și din Mesaje Directe, dar și link-ul „Site Web” și altele, care sunt de obicei ascunse folosind adrese URL scurtate. Extensia intră în acțiune doar când se navighează pe twitter.com sau twitter3e4tixl4xyajtrzo62zg5vztmjuricljdp2c5kshju4avyoid.onion.",
+    "message": "Dezvăluiește destinațiile originale ale link-urilor și ale Cardurilor Twitter din tweet-uri și răspunsuri cât și din Mesaje Directe, dar și link-ul „Site Web” și altele, care sunt de obicei ascunse folosind adrese URL scurtate. Extensia intră în acțiune doar când se navighează pe twitter.com.",
     "description": "Descrierea extensiei."
   },
   "enabledStateTitle": {

--- a/_locales/zh/messages.json
+++ b/_locales/zh/messages.json
@@ -4,7 +4,7 @@
     "description": "這個擴充功能的名稱。"
   },
   "extensionDescription": {
-    "message": "揭露被 Twitter 伺服器縮短的推文、回覆、直接訊息，以及\"網站\"連結等原本的連結目的地。此擴充功能只在瀏覽 twitter.com 或 twitter3e4tixl4xyajtrzo62zg5vztmjuricljdp2c5kshju4avyoid.onion 網站時啟動。",
+    "message": "揭露被 Twitter 伺服器縮短的推文、回覆、直接訊息，以及\"網站\"連結等原本的連結目的地。此擴充功能只在瀏覽 twitter.com 網站時啟動。",
     "description": "這個擴充功能的描述。"
   },
   "enabledStateTitle": {

--- a/manifest.json
+++ b/manifest.json
@@ -9,8 +9,7 @@
   "content_scripts": [
     {
       "matches": [
-        "*://*.twitter.com/*",
-        "*://*.twitter3e4tixl4xyajtrzo62zg5vztmjuricljdp2c5kshju4avyoid.onion/*"
+        "*://*.twitter.com/*"
       ],
       "js": [
         "scripts/content_script.js"
@@ -46,7 +45,6 @@
   },
   "permissions": [
     "*://*.twitter.com/*",
-    "*://*.twitter3e4tixl4xyajtrzo62zg5vztmjuricljdp2c5kshju4avyoid.onion/*",
     "storage",
     "tabs",
     "webRequest",

--- a/scripts/background_script.js
+++ b/scripts/background_script.js
@@ -161,7 +161,7 @@ TLD_background.interceptNetworkRequests = async function(requestDetails) {
   if (storedSettings.enabled !== true) {
     return;
   }    // don't clean the links if the add-on is not enabled
-  let tabs = await browser.tabs.query({discarded: false, url: ["*://*.twitter.com/*", "*://*.twitter3e4tixl4xyajtrzo62zg5vztmjuricljdp2c5kshju4avyoid.onion/*"]});
+  let tabs = await browser.tabs.query({discarded: false, url: ["*://*.twitter.com/*"]});
   //console.log(tabs);    // for debugging
   tabs.forEach(tab => {
     //console.log(tab);    // for debugging
@@ -628,6 +628,6 @@ browser.runtime.onMessage.addListener(TLD_background.handleMessage);    // liste
 
 browser.webRequest.onBeforeRequest.addListener(
   TLD_background.modifyNetworkRequests,
-  {urls: ["*://*.twitter.com/*","*://*.twitter3e4tixl4xyajtrzo62zg5vztmjuricljdp2c5kshju4avyoid.onion/*"]},
+  {urls: ["*://*.twitter.com/*"]},
   ["blocking"]
-);    // intercept the network responses from twitter.com or its Tor onion domain
+);    // intercept the network responses from twitter.com


### PR DESCRIPTION
Remove `twitter3e4tixl4xyajtrzo62zg5vztmjuricljdp2c5kshju4avyoid.onion`, X(Twitter) dropped the maintenance work a while, and its HTTPS certificate has been expired for more than one year.